### PR TITLE
Genenalize n_categorized_by and n_responsibility_by to multiple variables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: consequencestools
 Type: Package
 Title: Provides Support Tools for Data Analysis and Visualization 
     from the Ultimate Consequences Database
-Version: 0.0.0.9007
+Version: 0.0.0.9008
 Authors@R: 
     person(
     "Carwil", "Bjork-James",

--- a/R/event-responsibility-dated.R
+++ b/R/event-responsibility-dated.R
@@ -110,7 +110,7 @@ add_days_between <- function(event_date_table){
 #' @export
 #'
 #' @examples
-#' assign_state_responsibility_levels(deaths_aug24, simplify=TRUE) |>
+#' assign_state_responsibility_levels(deaths_aug24, simplify=TRUE) %>%
 #'   event_responsibility_summary_table()
 event_responsibility_summary_table <- function(dataframe) {
   de <- dataframe

--- a/man/event_responsibility_summary_table.Rd
+++ b/man/event_responsibility_summary_table.Rd
@@ -28,6 +28,6 @@ Each event will also have the following characteristics recorded:
 date (of first death), year, protest_domain, and presidential administration.
 }
 \examples{
-assign_state_responsibility_levels(deaths_aug24, simplify=TRUE) |>
+assign_state_responsibility_levels(deaths_aug24, simplify=TRUE) \%>\%
   event_responsibility_summary_table()
 }

--- a/man/n_categorized_by.Rd
+++ b/man/n_categorized_by.Rd
@@ -5,14 +5,14 @@
 \alias{n_responsibility_by}
 \title{Produce a Summary Table for Deaths by Responsibility and Major Domains}
 \usage{
-n_categorized_by(def, by, complete = FALSE, sp_binary = FALSE)
+n_categorized_by(def, ..., complete = FALSE, sp_binary = FALSE)
 
-n_responsibility_by(def, by, complete = FALSE)
+n_responsibility_by(def, ..., complete = FALSE)
 }
 \arguments{
 \item{def}{A data frame detailing deaths}
 
-\item{by}{A variable to summarize by}
+\item{...}{One or more variables to summarize by}
 
 \item{complete}{A logical value stating whether to fill in zero values}
 

--- a/tests/testthat/_snaps/n-categorized-by.md
+++ b/tests/testthat/_snaps/n-categorized-by.md
@@ -96,3 +96,53 @@
       10 Cable cut through neck      1            0              0                0
       # i 50 more rows
 
+---
+
+    Code
+      n_responsibility_by(deaths_aug24, department, dec_gender, complete = FALSE)
+    Output
+      # A tibble: 16 x 6
+         department dec_gender     n n_state_perp n_state_victim n_state_separate
+         <chr>      <chr>      <int>        <int>          <int>            <int>
+       1 Beni       F              3            1              0                1
+       2 Beni       M             18            5              1                7
+       3 Chuquisaca F              1            0              0                0
+       4 Chuquisaca M              9            8              1                0
+       5 Cochabamba F             12            6              1                3
+       6 Cochabamba M            159          102             29               17
+       7 La Paz     F             29           10              0                6
+       8 La Paz     M            220          125             25               41
+       9 Oruro      F             14            2              0               11
+      10 Oruro      M             42           10              1               30
+      11 Pando      M             14            2              1               11
+      12 Potosí     F             19            1              0               15
+      13 Potosí     M             33           13              1               18
+      14 Santa Cruz F              5            1              1                2
+      15 Santa Cruz M             51           15              2               30
+      16 Tarija     M              9            2              0                7
+
+---
+
+    Code
+      n_categorized_by(deaths_aug24, pres_admin, protest_domain, complete = TRUE)
+    Output
+      # A tibble: 240 x 17
+         pres_admin              protest_domain     n n_coca n_armedactor n_state_perp
+         <chr>                   <chr>          <int>  <int>        <int>        <int>
+       1 Carlos Diego Mesa Gisb~ Coca               7      7            0            2
+       2 Carlos Diego Mesa Gisb~ Contraband         0      0            0            0
+       3 Carlos Diego Mesa Gisb~ Disabled           0      0            0            0
+       4 Carlos Diego Mesa Gisb~ Drug trade         0      0            0            0
+       5 Carlos Diego Mesa Gisb~ Economic poli~     0      0            0            0
+       6 Carlos Diego Mesa Gisb~ Education          0      0            0            0
+       7 Carlos Diego Mesa Gisb~ Ethno-ecologi~     0      0            0            0
+       8 Carlos Diego Mesa Gisb~ Gas Wars           1      0            0            1
+       9 Carlos Diego Mesa Gisb~ Guerrilla          0      0            0            0
+      10 Carlos Diego Mesa Gisb~ Labor              0      0            0            0
+      # i 230 more rows
+      # i 11 more variables: n_state_perp_coca <int>, n_state_perp_armedactor <int>,
+      #   n_state_victim <int>, n_state_victim_coca <int>,
+      #   n_state_victim_armedactor <int>, n_state_separate <int>,
+      #   n_state_perp_ordinary <int>, n_state_victim_ordinary <int>,
+      #   n_remaining <int>, n_remaining_coca <int>, n_remaining_armedactor <int>
+

--- a/tests/testthat/test-n-categorized-by.R
+++ b/tests/testthat/test-n-categorized-by.R
@@ -17,9 +17,14 @@ test_that("Appropriately sized table for n_responsibility_by()", {
                nrow(unique(na.omit(deaths_aug24[,"department"]))))
   expect_equal(ncol(n_responsibility_by(deaths_aug24, protest_domain, complete=TRUE)),
                n_calculated_columns+1)
+  expect_equal(ncol(n_responsibility_by(deaths_aug24, pres_admin, protest_domain, complete=TRUE)),
+               n_calculated_columns+2)
   expect_equal(ncol(n_responsibility_by(deaths_aug24, department,
                                      complete=TRUE)),
                n_calculated_columns+1)
+  expect_equal(ncol(n_responsibility_by(deaths_aug24, department, dec_gender,
+                                        complete=TRUE)),
+               n_calculated_columns+2)
 })
 
 test_that("Results table is consistent with past runs", {
@@ -28,4 +33,6 @@ test_that("Results table is consistent with past runs", {
   expect_snapshot(n_categorized_by(deaths_aug24, pres_admin, complete=TRUE))
   expect_snapshot(n_categorized_by(deaths_aug24, pres_admin, complete=TRUE, sp_binary = TRUE))
   expect_snapshot(n_responsibility_by(deaths_aug24, cause_death, complete=TRUE))
+  expect_snapshot(n_responsibility_by(deaths_aug24, department, dec_gender, complete=FALSE))
+  expect_snapshot(n_categorized_by(deaths_aug24, pres_admin, protest_domain, complete=TRUE))
 })


### PR DESCRIPTION
### TL;DR

Enhanced the `n_categorized_by` and `n_responsibility_by` functions to support multiple grouping variables.

### What changed?

- Modified `n_categorized_by` and `n_responsibility_by` functions to accept multiple variables using `...` instead of a single `by` parameter
- Updated the implementation to use `across()` and `if_all()` to handle multiple grouping variables
- Added `ungroup()` calls to ensure the returned data frames are ungrouped
- Fixed the pipe operator in examples from `|>` to `%>%` for consistency
- Updated documentation to reflect the new parameter structure
- Added test cases to verify functionality with multiple grouping variables

### How to test?

Run the following examples to verify the enhanced functionality:

```r
# Single variable grouping (existing functionality)
n_categorized_by(deaths_aug24, pres_admin, complete=TRUE)
n_responsibility_by(deaths_aug24, department, complete=TRUE)

# Multiple variable grouping (new functionality)
n_categorized_by(deaths_aug24, pres_admin, protest_domain, complete=TRUE)
n_responsibility_by(deaths_aug24, department, dec_gender, complete=FALSE)
```

### Why make this change?

This enhancement provides more flexibility in data analysis by allowing users to group by multiple variables simultaneously. This is particularly useful for creating more detailed cross-tabulations and examining interactions between different categorical variables in the dataset.